### PR TITLE
fix to make second order work under julia-1.0

### DIFF
--- a/src/trs-core.jl
+++ b/src/trs-core.jl
@@ -68,7 +68,7 @@ pass(a::Pass, x::AbstractVector, idx::Int, cols::UnitRange) = pass(a,x,idx)[cols
 
 export inview
 
-inview(a::Pass, outview::UnitRange, inlength::Int, intype::AbstractVector) = Union{Missing,UnitRange}()
+inview(a::Pass, outview::UnitRange, inlength::Int, intype::AbstractVector) = Union{Missing}()
 
 export outlength
 


### PR DESCRIPTION
This makes https://github.com/ikizhvatov/jlsca-tutorials/blob/master/secondorder-ascad/second-order-cpa-ascad.ipynb work in julia-1.0